### PR TITLE
chore: test PR for Slack GitHub notifier

### DIFF
--- a/docs/slack-notifier-test-pr.md
+++ b/docs/slack-notifier-test-pr.md
@@ -1,0 +1,5 @@
+# Slack Notifier Test PR
+
+This file exists only to generate a pull request event for validating the TeamPulse GitHub → Slack notifier flow.
+
+Created on: 2026-02-23


### PR DESCRIPTION
## Purpose
Test-only PR to trigger GitHub pull request webhook events and verify Slack notifications from TeamPulse.

## Change
- Added `docs/slack-notifier-test-pr.md`

## Notes
No functional contract logic changed.